### PR TITLE
Pass fused pipeline components through Flink translation context

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPipelineTranslator.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.flink;
 
 import javax.annotation.Nullable;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -44,8 +45,9 @@ class FlinkBatchPipelineTranslator extends FlinkPipelineTranslator {
 
   private int depth = 0;
 
-  public FlinkBatchPipelineTranslator(ExecutionEnvironment env, PipelineOptions options) {
-    this.batchContext = new FlinkBatchTranslationContext(env, options);
+  public FlinkBatchPipelineTranslator(ExecutionEnvironment env, PipelineOptions options,
+      RunnerApi.Components components) {
+    this.batchContext = new FlinkBatchTranslationContext(env, options, components);
   }
 
   @Override

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchTransformTranslators.java
@@ -715,11 +715,8 @@ class FlinkBatchTransformTranslators {
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
-      @SuppressWarnings("unchecked")
-      RunnerApi.Components components = PipelineTranslation.toProto(
-          context.getCurrentTransform().getPipeline()).getComponents();
       FlinkExecutableStageFunction<InputT, OutputT> function =
-          new FlinkExecutableStageFunction<>(stagePayload, components);
+          new FlinkExecutableStageFunction<>(stagePayload, context.getComponents());
       DataSet<WindowedValue<InputT>> inputDataSet =
           context.getInputDataSet(context.getInput(transform));
       DataSet<WindowedValue<OutputT>> outputDataset =

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchTranslationContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchTranslationContext.java
@@ -20,6 +20,7 @@ package org.apache.beam.runners.flink;
 import com.google.common.collect.Iterables;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.core.construction.TransformInputs;
 import org.apache.beam.runners.flink.translation.types.CoderTypeInformation;
 import org.apache.beam.sdk.coders.Coder;
@@ -54,14 +55,17 @@ class FlinkBatchTranslationContext {
 
   private final ExecutionEnvironment env;
   private final PipelineOptions options;
+  private final RunnerApi.Components components;
 
   private AppliedPTransform<?, ?, ?> currentTransform;
 
   // ------------------------------------------------------------------------
 
-  public FlinkBatchTranslationContext(ExecutionEnvironment env, PipelineOptions options) {
+  public FlinkBatchTranslationContext(ExecutionEnvironment env, PipelineOptions options,
+      RunnerApi.Components components) {
     this.env = env;
     this.options = options;
+    this.components = components;
     this.dataSets = new HashMap<>();
     this.broadcastDataSets = new HashMap<>();
 
@@ -80,6 +84,10 @@ class FlinkBatchTranslationContext {
 
   public PipelineOptions getPipelineOptions() {
     return options;
+  }
+
+  public RunnerApi.Components getComponents() {
+    return components;
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
ExecutableStage components are were lost in translation between fusion and rehydration. This was due to ExecutableStagePayloads being stuffed into FunctionSpecs as opaque bytes and not having component ids updated as necessary.

To get around the component id translation problem, we now pass around the original set of components.